### PR TITLE
Catch up to unified submission deadline

### DIFF
--- a/id-checklist
+++ b/id-checklist
@@ -169,9 +169,8 @@ about it.
 N.  Submission Deadlines
 
 Before each IETF meeting, a deadline is announced for submitting documents
-ahead of time to be published for discussion at the meeting. For new
-documents, the deadline is one week earlier than for revisions of existing
-drafts. The only exception is for version -00 working group drafts that
+ahead of time to be published for discussion at the meeting.
+The only exception is for version -00 working group drafts that
 replace existing non-working-group documents; these documents may be
 submitted up to the deadline for new versions of existing documents.
 


### PR DESCRIPTION
There is no longer a different deadline for -00s than for revisions.